### PR TITLE
feat(cli): fail with exit code when findings detected

### DIFF
--- a/src/mcp_scanner/cli.py
+++ b/src/mcp_scanner/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import sys
 from typing import Optional, Any, Dict, Iterator, List
 
 import click
@@ -208,7 +209,13 @@ def scan_cmd(url: str, spec: Optional[str], fmt: str, verbose: bool, explain_id:
             else:
                 for line in _explain_single(f, spec_index, list(trace) if isinstance(trace, list) else []):
                     console.print(f"- {line}")
-
+    failed = [f for f in report.findings if not f.passed]
+    if failed:
+        console.print(f"[red]Scan failed: {len(failed)} findings[/red]")
+        sys.exit(1)
+    else:
+        console.print("[green]All checks passed[/green]")
+        sys.exit(0)
 
 @main.command("scan-range")
 @click.option("--host", required=True, help="Target host, e.g., localhost")


### PR DESCRIPTION
Previously, the CLI always returned 0, even if findings were detected. This made it difficult to use in CI pipelines, since failures could not be detected automatically.

Now, the CLI exits with:
- 0 when all checks pass
- 1 when one or more findings fail

This allows CI/CD jobs to fail early and clearly when security checks detect issues, while still generating a full report for inspection.